### PR TITLE
feat: apply Jura font globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: system-ui, sans-serif;
+  --font-sans: var(--font-jura), system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
 }
@@ -23,5 +23,4 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,4 +1,10 @@
 import "./globals.css";
+import { Jura } from "next/font/google";
+
+const jura = Jura({
+  subsets: ["latin"],
+  variable: "--font-jura",
+});
 
 export const metadata = {
   title: "Create Next App",
@@ -7,7 +13,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" className={jura.variable}>
       <body className="antialiased font-sans">
         {children}
       </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,14 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require("tailwindcss/defaultTheme");
+
 module.exports = {
-    content: [
-        "./app/**/*.{js,ts,jsx,tsx}",
-        "./components/**/*.{js,ts,jsx,tsx}",
-    ],
-    theme: {
-        extend: {},
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-jura)", ...defaultTheme.fontFamily.sans],
+      },
     },
-    plugins: [],
-}
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- load Jura font with `next/font` and apply across the app
- set Tailwind's default sans family to Jura
- update global CSS theme to reference the Jura font

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e1c31bb08325a074666922f496d7