### PR TITLE
feat: add mobile dropdown menu

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -1,15 +1,48 @@
 'use client';
 import Link from "next/link";
+import { useState, useRef, useEffect } from "react";
+import { Menu, X } from "lucide-react";
 
 export default function Header() {
+    const [open, setOpen] = useState(false);
+    const menuRef = useRef(null);
+    const buttonRef = useRef(null);
+
+    useEffect(() => {
+        function handleClickOutside(event) {
+            if (
+                open &&
+                menuRef.current &&
+                !menuRef.current.contains(event.target) &&
+                buttonRef.current &&
+                !buttonRef.current.contains(event.target)
+            ) {
+                setOpen(false);
+            }
+        }
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, [open]);
+
     return (
-        <header className="flex justify-between items-center p-6 bg-white shadow-md sticky top-0 z-50">
+        <header className="flex justify-between items-center p-6 bg-white shadow-md sticky top-0 z-50 relative">
             <div className="text-xl font-bold">&lt;devnai&gt;</div>
-            <nav className="space-x-6 text-sm">
-                <Link href="#about">About Me</Link>
-                <Link href="#projects">Projects</Link>
-                <Link href="#journey">My Journey</Link>
-                <Link href="#contact">Contact</Link>
+            <button
+                ref={buttonRef}
+                className="md:hidden"
+                onClick={() => setOpen((o) => !o)}
+                aria-label="Toggle navigation menu"
+            >
+                {open ? <X /> : <Menu />}
+            </button>
+            <nav
+                ref={menuRef}
+                className={`text-sm ${open ? "block" : "hidden"} md:flex md:space-x-6 absolute md:static top-full left-0 right-0 bg-white md:bg-transparent shadow-md md:shadow-none`}
+            >
+                <Link href="#about" className="block px-6 py-2 md:p-0">About Me</Link>
+                <Link href="#projects" className="block px-6 py-2 md:p-0">Projects</Link>
+                <Link href="#journey" className="block px-6 py-2 md:p-0">My Journey</Link>
+                <Link href="#contact" className="block px-6 py-2 md:p-0">Contact</Link>
             </nav>
         </header>
     );


### PR DESCRIPTION
## Summary
- add responsive mobile dropdown to header
- close mobile nav when clicking outside

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39510f98483258c3e226b9ba3b48b