### PR TITLE
Use black backgrounds and white text for dark mode

### DIFF
--- a/app/components/About.jsx
+++ b/app/components/About.jsx
@@ -3,7 +3,7 @@ export default function About() {
         <section
             id="about"
             style={{ backgroundImage: "url('/background.jpeg')" }}
-            className="flex flex-col md:flex-row items-center justify-center gap-12 py-20 bg-gray-50 dark:bg-gray-900"
+            className="flex flex-col md:flex-row items-center justify-center gap-12 py-20 bg-gray-50 dark:bg-black"
         >
             <img
                 src="/nai-photo.png"
@@ -11,11 +11,11 @@ export default function About() {
                 className="w-96 lg:w-[28rem] xl:w-[32rem] rounded-full shadow-lg mb-6 md:mb-0"
             />
             <div className="max-w-md lg:max-w-lg xl:max-w-xl text-center md:text-left">
-                <h2 className="text-3xl lg:text-4xl xl:text-5xl font-bold mb-4 text-gray-900 dark:text-gray-100">ABOUT ME</h2>
-                <p className="mb-2 text-lg lg:text-xl text-gray-700 dark:text-gray-300">Building software with structure and vision</p>
+                <h2 className="text-3xl lg:text-4xl xl:text-5xl font-bold mb-4 text-gray-900 dark:text-white">ABOUT ME</h2>
+                <p className="mb-2 text-lg lg:text-xl text-gray-700 dark:text-white">Building software with structure and vision</p>
                 <p className="text-teal-500 font-semibold mb-2 text-lg lg:text-xl hover:text-teal-600 hover:shadow-lg hover:rounded-lg">Full Stack Developer</p>
-                <p className="text-lg lg:text-xl text-gray-700 dark:text-gray-300">Civil Engineer</p>
-                <p className="mb-4 text-lg lg:text-xl text-gray-700 dark:text-gray-300">Project Manager</p>
+                <p className="text-lg lg:text-xl text-gray-700 dark:text-white">Civil Engineer</p>
+                <p className="mb-4 text-lg lg:text-xl text-gray-700 dark:text-white">Project Manager</p>
                 {/* <a
                     href="/resume.pdf"
                     download

--- a/app/components/Contact.jsx
+++ b/app/components/Contact.jsx
@@ -1,8 +1,8 @@
 export default function Contact() {
     return (
-        <section id="contact" className="py-20 px-6 bg-white dark:bg-gray-900 text-center">
-            <h2 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">Contact</h2>
-            <p className="text-gray-700 dark:text-gray-300">Let's build something together.</p>
+        <section id="contact" className="py-20 px-6 bg-white dark:bg-black text-center">
+            <h2 className="text-3xl font-bold mb-6 text-gray-900 dark:text-white">Contact</h2>
+            <p className="text-gray-700 dark:text-white">Let's build something together.</p>
             <a
                 href="mailto:naiara@example.com"
                 className="mt-4 inline-block bg-teal-500 text-white py-2 px-6 rounded hover:bg-teal-600 transition"

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -44,7 +44,7 @@ export default function Footer() {
     ];
 
     return (
-        <footer className="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white relative">
+        <footer className="bg-gray-100 text-gray-900 dark:bg-black dark:text-white relative">
             {/* Scroll to top button */}
             {showScrollTop && (
                 <button
@@ -62,7 +62,7 @@ export default function Footer() {
                     {/* Connect section */}
                     <div>
                         <h4 className="text-lg font-semibold mb-4 text-teal-400">Let's Connect</h4>
-                        <p className="text-gray-700 dark:text-gray-300 text-sm mb-4">
+                        <p className="text-gray-700 dark:text-white text-sm mb-4">
                             I'm always open to discussing new opportunities and interesting projects.
                         </p>
                         <div className="flex justify-center space-x-4">
@@ -74,7 +74,7 @@ export default function Footer() {
                                         href={social.url}
                                         target={social.name !== 'Email' ? '_blank' : undefined}
                                         rel={social.name !== 'Email' ? 'noopener noreferrer' : undefined}
-                                        className={`p-2 bg-gray-200 dark:bg-gray-800 rounded-lg transition-all duration-200 hover:bg-gray-300 dark:hover:bg-gray-700 ${social.color} hover:scale-110`}
+                                        className={`p-2 bg-gray-200 dark:bg-black rounded-lg transition-all duration-200 hover:bg-gray-300 dark:hover:bg-black ${social.color} hover:scale-110`}
                                         aria-label={social.name}
                                     >
                                         <Icon className="w-5 h-5" />
@@ -88,13 +88,13 @@ export default function Footer() {
                 {/* Bottom section */}
                 <div className="border-t border-gray-300 dark:border-gray-700 mt-12 pt-8">
                     <div className="flex flex-col items-center space-y-4">
-                        <div className="flex items-center space-x-1 text-sm text-gray-600 dark:text-gray-400">
+                        <div className="flex items-center space-x-1 text-sm text-gray-600 dark:text-white">
                             <span>&copy; {currentYear} Crafted by Naiara Costa. Made with</span>
                             <Heart className="w-4 h-4 text-red-500 animate-pulse" />
                             <span>using Next.js & Tailwind CSS</span>
                         </div>
 
-                        <div className="flex items-center space-x-6 text-sm text-gray-600 dark:text-gray-400">
+                        <div className="flex items-center space-x-6 text-sm text-gray-600 dark:text-white">
 
                             <a
                                 href="/privacy-policy"

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -26,7 +26,7 @@ export default function Header() {
     }, [open]);
 
     return (
-        <header className="flex justify-between items-center p-6 bg-white dark:bg-gray-900 shadow-md sticky top-0 z-50 relative">
+        <header className="flex justify-between items-center p-6 bg-white dark:bg-black shadow-md sticky top-0 z-50 relative">
             <div className="text-xl font-bold">&lt;devnai&gt;</div>
             <button
                 ref={buttonRef}
@@ -38,7 +38,7 @@ export default function Header() {
             </button>
             <nav
                 ref={menuRef}
-                className={`text-sm ${open ? "block" : "hidden"} md:flex md:space-x-6 absolute md:static top-full left-0 right-0 bg-white dark:bg-gray-900 md:bg-transparent md:dark:bg-transparent shadow-md md:shadow-none`}
+                className={`text-sm ${open ? "block" : "hidden"} md:flex md:space-x-6 absolute md:static top-full left-0 right-0 bg-white dark:bg-black md:bg-transparent md:dark:bg-transparent shadow-md md:shadow-none`}
             >
                 <Link href="#about" className="block px-6 py-2 md:p-0">About Me</Link>
                 <Link href="#projects" className="block px-6 py-2 md:p-0">Projects</Link>

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -1,8 +1,8 @@
 export default function Hero() {
     return (
         <section className="text-center py-20">
-            <h1 className="text-4xl md:text-6xl font-bold mb-8 text-gray-900 dark:text-gray-100">Hi, I'm Naiara Costa</h1>
-            <div className="mx-auto max-w-7xl justify-center items-center text-lg md:text-xl text-gray-700 dark:text-gray-300 mb-8">
+            <h1 className="text-4xl md:text-6xl font-bold mb-8 text-gray-900 dark:text-white">Hi, I'm Naiara Costa</h1>
+            <div className="mx-auto max-w-7xl justify-center items-center text-lg md:text-xl text-gray-700 dark:text-white mb-8">
                 <p className="mb-8 mx-4">
                     Civil Engineer turned Developer. I build useful things with code and caffeine.
                 </p>

--- a/app/components/Journey.jsx
+++ b/app/components/Journey.jsx
@@ -195,11 +195,11 @@ export default function Journey() {
     };
 
     return (
-        <section id="journey" className="py-20 px-6 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
+        <section id="journey" className="py-20 px-6 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-black dark:to-black">
             <div className="max-w-4xl mx-auto">
                 <div className="text-center mb-16">
-                    <h2 className="text-4xl font-bold text-gray-800 dark:text-gray-100 mb-4">My Journey</h2>
-                    <p className="text-gray-600 dark:text-gray-300 text-lg">Tracing the path of growth and learning</p>
+                    <h2 className="text-4xl font-bold text-gray-800 dark:text-white mb-4">My Journey</h2>
+                    <p className="text-gray-600 dark:text-white text-lg">Tracing the path of growth and learning</p>
                 </div>
 
                 <div className="relative">
@@ -219,7 +219,7 @@ export default function Journey() {
                                 {/* Content card */}
                                 <div className={`ml-16 md:ml-0 md:w-6/12 ${!isEven ? 'md:mr-auto md:pr-8' : 'md:ml-auto md:pl-8'}`}>
                                       <div
-                                          className={`bg-white dark:bg-gray-800 rounded-xl shadow-lg border ${colors.border} dark:border-gray-700 p-6 transform transition-all duration-300 cursor-pointer ${activeItem === index ? 'scale-105 shadow-xl' : colors.hover
+                                      className={`bg-white dark:bg-black rounded-xl shadow-lg border ${colors.border} dark:border-gray-700 p-6 transform transition-all duration-300 cursor-pointer ${activeItem === index ? 'scale-105 shadow-xl' : colors.hover
                                               }`}
                                         onClick={() => setActiveItem(activeItem === index ? -1 : index)}
                                     >
@@ -230,17 +230,17 @@ export default function Journey() {
                                                     <Icon className="w-5 h-5 text-white" />
                                                 </div>
                                                 <div>
-                                                    <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100">{item.title}</h3>
-                                                    <p className={`${colors.text} font-semibold dark:text-gray-300`}>{item.role}</p>
+                                                    <h3 className="text-xl font-bold text-gray-800 dark:text-white">{item.title}</h3>
+                                                    <p className={`${colors.text} font-semibold dark:text-white`}>{item.role}</p>
                                                 </div>
                                             </div>
-                                              <span className={`text-sm ${colors.text} bg-gray-50 dark:bg-gray-900 px-3 py-1 rounded-full font-medium`}>
+                                              <span className={`text-sm ${colors.text} bg-gray-50 dark:bg-black px-3 py-1 rounded-full font-medium`}>
                                                 {item.period}
                                             </span>
                                         </div>
 
                                         {/* Company and location */}
-                                          <div className="flex items-center space-x-4 mb-4 text-gray-600 dark:text-gray-300">
+                                          <div className="flex items-center space-x-4 mb-4 text-gray-600 dark:text-white">
                                             <div className="flex items-center space-x-1">
                                                 <Briefcase className="w-4 h-4" />
                                                 <span className="text-sm">{item.company}</span>
@@ -252,7 +252,7 @@ export default function Journey() {
                                         </div>
 
                                         {/* Description */}
-                                          <p className={`text-gray-600 dark:text-gray-300 leading-relaxed transition-all duration-300 ${activeItem === index ? 'mb-4' : 'mb-0'
+                                          <p className={`text-gray-600 dark:text-white leading-relaxed transition-all duration-300 ${activeItem === index ? 'mb-4' : 'mb-0'
                                               }`}>
                                             {item.description}
                                         </p>
@@ -261,12 +261,12 @@ export default function Journey() {
                                         <div className={`transition-all duration-300 overflow-hidden ${activeItem === index ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0'
                                             }`}>
                                               <div className="pt-4 border-t border-gray-100 dark:border-gray-700">
-                                                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Technologies & Skills:</h4>
+                                                  <h4 className="text-sm font-semibold text-gray-700 dark:text-white mb-2">Technologies & Skills:</h4>
                                                 <div className="flex flex-wrap gap-2">
                                                     {item.skills.map((skill, skillIndex) => (
                                                           <span
                                                               key={skillIndex}
-                                                              className={`px-3 py-1 ${colors.text} bg-gray-50 dark:bg-gray-900 rounded-full text-sm font-medium border ${colors.border} dark:border-gray-700`}
+                                                              className={`px-3 py-1 ${colors.text} bg-gray-50 dark:bg-black rounded-full text-sm font-medium border ${colors.border} dark:border-gray-700`}
                                                           >
                                                             {skill}
                                                         </span>
@@ -289,9 +289,9 @@ export default function Journey() {
 
                 {/* Call to action */}
                     <div className="text-center mt-16">
-                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 border border-gray-200 dark:border-gray-700">
-                        <h3 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">Ready for the Next Chapter</h3>
-                        <p className="text-gray-600 dark:text-gray-300 mb-6">
+                    <div className="bg-white dark:bg-black rounded-xl shadow-lg p-8 border border-gray-200 dark:border-gray-700">
+                        <h3 className="text-2xl font-bold text-gray-800 dark:text-white mb-4">Ready for the Next Chapter</h3>
+                        <p className="text-gray-600 dark:text-white mb-6">
                             I'm excited to bring my skills and passion to new challenges and opportunities.
                         </p>
                         {/* <a

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -84,13 +84,13 @@ export default function Projects() {
     }, [currentIndex, slidesToShow]);
 
     return (
-        <section id="projects" className="py-20 px-6 bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
+        <section id="projects" className="py-20 px-6 bg-gradient-to-br from-gray-50 to-white dark:from-black dark:to-black">
             <div className="max-w-7xl mx-auto">
                 <div className="text-center mb-16">
-                    <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+                    <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
                         Featured Projects
                     </h2>
-                    <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+                    <p className="text-xl text-gray-600 dark:text-white max-w-3xl mx-auto">
                         A showcase of my recent work in web development, featuring modern designs and innovative solutions.
                     </p>
                 </div>
@@ -109,7 +109,7 @@ export default function Projects() {
                                     key={index}
                                     className="w-full md:w-1/2 lg:w-1/3 flex-shrink-0 px-3"
                                 >
-                                    <div className="group bg-white dark:bg-gray-800 rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 overflow-hidden">
+                                    <div className="group bg-white dark:bg-black rounded-xl shadow-lg hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 overflow-hidden">
                                         {/* Image Container */}
                                         <div className="relative overflow-hidden">
                                             <img
@@ -125,7 +125,7 @@ export default function Projects() {
                                                     href={project.link}
                                                     target={project.link.startsWith('http') ? '_blank' : '_self'}
                                                     rel={project.link.startsWith('http') ? 'noopener noreferrer' : ''}
-                                                    className="bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm text-gray-900 dark:text-gray-100 px-6 py-3 rounded-full font-semibold hover:bg-white dark:hover:bg-gray-800 transition-colors duration-200 flex items-center gap-2 transform translate-y-4 group-hover:translate-y-0"
+                                                    className="bg-white/90 dark:bg-black/90 backdrop-blur-sm text-gray-900 dark:text-white px-6 py-3 rounded-full font-semibold hover:bg-white dark:hover:bg-black transition-colors duration-200 flex items-center gap-2 transform translate-y-4 group-hover:translate-y-0"
                                                 >
                                                     <ExternalLink size={18} />
                                                     View Project
@@ -135,10 +135,10 @@ export default function Projects() {
 
                                         {/* Content */}
                                         <div className="p-6">
-                                            <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-3 group-hover:text-teal-600 transition-colors duration-200">
+                                            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-teal-600 transition-colors duration-200">
                                                 {project.title}
                                             </h3>
-                                            <p className="text-gray-600 dark:text-gray-300 line-clamp-3">
+                                            <p className="text-gray-600 dark:text-white line-clamp-3">
                                                 {project.description}
                                             </p>
                                         </div>
@@ -151,7 +151,7 @@ export default function Projects() {
                     {/* Navigation Arrows */}
                     <button
                         onClick={prevSlide}
-                        className="absolute left-4 top-1/2 -translate-y-1/2 bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-800 text-gray-800 dark:text-gray-100 p-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 z-10 group"
+                        className="absolute left-4 top-1/2 -translate-y-1/2 bg-white/90 dark:bg-black/90 backdrop-blur-sm hover:bg-white dark:hover:bg-black text-gray-800 dark:text-white p-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 z-10 group"
                         aria-label="Previous project"
                     >
                         <ChevronLeft size={24} className="group-hover:scale-110 transition-transform duration-200" />
@@ -159,7 +159,7 @@ export default function Projects() {
 
                     <button
                         onClick={nextSlide}
-                        className="absolute right-4 top-1/2 -translate-y-1/2 bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-800 text-gray-800 dark:text-gray-100 p-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 z-10 group"
+                        className="absolute right-4 top-1/2 -translate-y-1/2 bg-white/90 dark:bg-black/90 backdrop-blur-sm hover:bg-white dark:hover:bg-black text-gray-800 dark:text-white p-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 z-10 group"
                         aria-label="Next project"
                     >
                         <ChevronRight size={24} className="group-hover:scale-110 transition-transform duration-200" />
@@ -173,7 +173,7 @@ export default function Projects() {
                                 onClick={() => goToSlide(index)}
                                 className={`w-3 h-3 rounded-full transition-all duration-300 ${currentIndex === index
                                     ? 'bg-teal-600 scale-125'
-                                    : 'bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500'
+                                    : 'bg-gray-300 dark:bg-black hover:bg-gray-400 dark:hover:bg-black'
                                     }`}
                                 aria-label={`Go to slide ${index + 1}`}
                             />

--- a/app/components/Skills.jsx
+++ b/app/components/Skills.jsx
@@ -92,7 +92,7 @@ const Skills = () => {
     ];
 
     const SkillCard = ({ category, icon, skills, color }) => (
-        <div className="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 border border-gray-100 dark:border-gray-700">
+        <div className="group relative bg-white dark:bg-black rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 border border-gray-100 dark:border-gray-700">
             {/* Gradient background overlay */}
             <div className={`absolute inset-0 bg-gradient-to-br ${color} opacity-0 group-hover:opacity-5 rounded-2xl transition-opacity duration-300`}></div>
 
@@ -101,7 +101,7 @@ const Skills = () => {
                 <div className={`p-2 rounded-lg bg-gradient-to-r ${color} text-white`}>
                     {icon}
                 </div>
-                <h3 className="font-semibold text-gray-800 dark:text-gray-100 text-lg">{category}</h3>
+                <h3 className="font-semibold text-gray-800 dark:text-white text-lg">{category}</h3>
             </div>
 
             {/* Skills */}
@@ -109,10 +109,10 @@ const Skills = () => {
                 {skills.map((skill, index) => (
                     <div
                         key={index}
-                        className="flex items-center space-x-2 py-2 px-3 rounded-lg bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors duration-200"
+                        className="flex items-center space-x-2 py-2 px-3 rounded-lg bg-gray-50 dark:bg-black hover:bg-gray-100 dark:hover:bg-black transition-colors duration-200"
                     >
                         <div className={`w-2 h-2 rounded-full bg-gradient-to-r ${color}`}></div>
-                        <span className="text-gray-700 dark:text-gray-300 text-sm font-medium">{skill}</span>
+                        <span className="text-gray-700 dark:text-white text-sm font-medium">{skill}</span>
                     </div>
                 ))}
             </div>
@@ -120,26 +120,26 @@ const Skills = () => {
     );
 
     return (
-        <section className="min-h-screen bg-white dark:bg-gray-900 from-slate-50 via-blue-50 to-indigo-50 dark:from-gray-800 dark:via-gray-800 dark:to-gray-900 py-16 px-4">
+        <section className="min-h-screen bg-white dark:bg-black from-slate-50 via-blue-50 to-indigo-50 dark:from-black dark:via-black dark:to-black py-16 px-4">
             <div className="max-w-7xl mx-auto">
                 {/* Header */}
                 <div className="text-center mb-12">
-                    <h2 className="text-4xl md:text-5xl font-bold text-gray-800 dark:text-gray-100 mb-4">
+                    <h2 className="text-4xl md:text-5xl font-bold text-gray-800 dark:text-white mb-4">
                         Skills & Expertise
                     </h2>
-                    <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+                    <p className="text-lg text-gray-600 dark:text-white max-w-2xl mx-auto">
                         A comprehensive overview of my technical abilities and professional competencies
                     </p>
                 </div>
 
                 {/* Tab Navigation */}
                 <div className="flex justify-center mb-12">
-                    <div className="bg-white dark:bg-gray-800 rounded-2xl p-2 shadow-lg border border-gray-200 dark:border-gray-700">
+                    <div className="bg-white dark:bg-black rounded-2xl p-2 shadow-lg border border-gray-200 dark:border-gray-700">
                         <button
                             onClick={() => setActiveTab("hard")}
                             className={`flex items-center space-x-2 px-6 py-3 rounded-xl font-semibold transition-all duration-300 ${activeTab === "hard"
                                 ? "bg-gradient-to-r bg-teal-500 text-white shadow-lg"
-                                : "text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100"
+                                : "text-gray-600 hover:text-gray-800 dark:text-white dark:hover:text-white"
                                 }`}
                         >
                             <Wrench className="w-5 h-5" />
@@ -149,7 +149,7 @@ const Skills = () => {
                             onClick={() => setActiveTab("soft")}
                             className={`flex items-center space-x-2 px-6 py-3 rounded-xl font-semibold transition-all duration-300 ${activeTab === "soft"
                                 ? "bg-gradient-to-r bg-pink-500 text-white shadow-lg"
-                                : "text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100"
+                                : "text-gray-600 hover:text-gray-800 dark:text-white dark:hover:text-white"
                                 }`}
                         >
                             <Heart className="w-5 h-5" />
@@ -170,23 +170,23 @@ const Skills = () => {
                 </div>
 
                 {/* Stats Footer */}
-                <div className="mt-16 bg-white dark:bg-gray-800 rounded-2xl p-8 shadow-lg border border-gray-100 dark:border-gray-700">
+                <div className="mt-16 bg-white dark:bg-black rounded-2xl p-8 shadow-lg border border-gray-100 dark:border-gray-700">
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
                         <div>
                             <div className="text-3xl font-bold text-blue-600 mb-2">{hardSkills.reduce((acc, group) => acc + group.skills.length, 0)}</div>
-                            <div className="text-gray-600 dark:text-gray-300 font-medium">Technical Skills</div>
+                            <div className="text-gray-600 dark:text-white font-medium">Technical Skills</div>
                         </div>
                         <div>
                             <div className="text-3xl font-bold text-pink-600 mb-2">{softSkills.reduce((acc, group) => acc + group.skills.length, 0)}</div>
-                            <div className="text-gray-600 dark:text-gray-300 font-medium">Soft Skills</div>
+                            <div className="text-gray-600 dark:text-white font-medium">Soft Skills</div>
                         </div>
                         <div>
                             <div className="text-3xl font-bold text-green-600 mb-2">{hardSkills.length}</div>
-                            <div className="text-gray-600 dark:text-gray-300 font-medium">Tech Categories</div>
+                            <div className="text-gray-600 dark:text-white font-medium">Tech Categories</div>
                         </div>
                         <div>
                             <div className="text-3xl font-bold text-purple-600 mb-2">{softSkills.length}</div>
-                            <div className="text-gray-600 dark:text-gray-300 font-medium">Professional Areas</div>
+                            <div className="text-gray-600 dark:text-white font-medium">Professional Areas</div>
                         </div>
                     </div>
                 </div>

--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -23,7 +23,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-black transition-colors"
       aria-label="Toggle Dark Mode"
     >
       {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,8 +14,8 @@
 }
 
 .dark {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: #000000;
+  --foreground: #ffffff;
 }
 
 body {

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -12,7 +12,7 @@ export default function PrivacyPolicyPage() {
         <main className="mx-auto max-w-3xl px-6 py-16">
             <header className="mb-8">
                 <h1 className="text-3xl font-bold tracking-tight">Privacy Policy</h1>
-                <p className="text-sm text-gray-500">Last updated: {lastUpdated}</p>
+                <p className="text-sm text-gray-500 dark:text-white">Last updated: {lastUpdated}</p>
             </header>
 
             <section className="prose prose-neutral dark:prose-invert">

--- a/app/terms-of-use/page.jsx
+++ b/app/terms-of-use/page.jsx
@@ -7,7 +7,7 @@ export default function TermsOfUse() {
         <main className="mx-auto max-w-3xl px-6 py-16">
             <header className="mb-8">
                 <h1 className="text-3xl font-bold tracking-tight">Terms of Use</h1>
-                <p className="text-sm text-gray-500">Last updated: {lastUpdated}</p>
+                <p className="text-sm text-gray-500 dark:text-white">Last updated: {lastUpdated}</p>
             </header>
 
             <section className="prose prose-invert prose-headings:scroll-mt-28">


### PR DESCRIPTION
## Summary
- Default dark theme now uses black backgrounds and white text
- Updated portfolio components to respect the new dark styling while keeping accent colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb4f3e12083258838888eced7f0f2