### PR TITLE
fix: apply global dark theme

### DIFF
--- a/app/components/ThemeProvider.jsx
+++ b/app/components/ThemeProvider.jsx
@@ -3,7 +3,8 @@ import { createContext, useContext, useEffect, useState } from 'react';
 
 const ThemeContext = createContext({
     theme: 'light',
-    setTheme: () => { },
+    setTheme: () => {},
+    toggleTheme: () => {},
 });
 
 export const useTheme = () => {
@@ -36,12 +37,15 @@ export function ThemeProvider({ children, ...props }) {
 
     const applyTheme = (newTheme) => {
         const root = document.documentElement;
+        const body = document.body;
 
         // Remove both classes first
         root.classList.remove('light', 'dark');
+        body.classList.remove('light', 'dark');
 
-        // Add the new theme class
+        // Add the new theme class to root and body
         root.classList.add(newTheme);
+        body.classList.add(newTheme);
 
         console.log('Applied theme:', newTheme, 'Classes:', root.className); // Debug log
     };
@@ -53,9 +57,14 @@ export function ThemeProvider({ children, ...props }) {
         applyTheme(newTheme);
     };
 
+    const toggleTheme = () => {
+        setTheme(theme === 'dark' ? 'light' : 'dark');
+    };
+
     const value = {
         theme: mounted ? theme : 'light',
         setTheme,
+        toggleTheme,
         mounted, // Expose mounted state for debugging
     };
 

--- a/app/components/ThemeToggle.jsx
+++ b/app/components/ThemeToggle.jsx
@@ -3,12 +3,11 @@ import { Moon, Sun } from 'lucide-react';
 import { useTheme } from './ThemeProvider'; // Adjust path as needed
 
 export default function ThemeToggle() {
-  const { theme, setTheme, mounted } = useTheme();
+  const { theme, toggleTheme, mounted } = useTheme();
 
-  const toggleTheme = () => {
-    const newTheme = theme === 'dark' ? 'light' : 'dark';
-    console.log('Toggling from', theme, 'to', newTheme); // Debug log
-    setTheme(newTheme);
+  const handleToggle = () => {
+    console.log('Toggling from', theme, 'to', theme === 'dark' ? 'light' : 'dark'); // Debug log
+    toggleTheme();
   };
 
   // Show loading state until mounted
@@ -27,7 +26,7 @@ export default function ThemeToggle() {
   return (
     <div className="flex items-center gap-2">
       <button
-        onClick={toggleTheme}
+        onClick={handleToggle}
         className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors border border-gray-300 dark:border-gray-600"
         aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
       >


### PR DESCRIPTION
## Summary
- ensure global dark/light classes are applied to both `<html>` and `<body>`
- expose `toggleTheme` in theme context and consume it in `ThemeToggle`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc5f943c0832593ef2858f7b4e490